### PR TITLE
Update docs for proper installation of cli by cargo subcommand

### DIFF
--- a/docs/development/integration.md
+++ b/docs/development/integration.md
@@ -65,7 +65,7 @@ If you decide to use Tauri as a local package with npm (not yarn), you will have
 This will install `tauri-cli` as a Cargo subcommand on the cargo binary folder (by default on `$HOME/.cargo/bin`):
 
 ```bash
-cargo install tauri-cli --version ^1.0.0-beta
+cargo install tauri-cli --git https://github.com/tauri-apps/tauri --branch next
 ```
 
 For more installation options, see [`cargo install`](https://doc.rust-lang.org/cargo/commands/cargo-install.html#description)


### PR DESCRIPTION
got 3 errors installing cli
according to https://github.com/tauri-apps/tauri/issues/3050
the install line must be changed to pull from the next branch from github

Note: I did the cargo subcommand option when I had issues with yarn.  I got yarn running, but wanted to get docs updated for others. 
I hope this makes sense.  I am just getting into tauri today.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
